### PR TITLE
[Feat(user)/#117] 가게별 메뉴 전체 조회, 카테고리별 가게 조회, 카테고리 가져오기 API 및 Provider 구현

### DIFF
--- a/lib/all/screens/login_screen.dart
+++ b/lib/all/screens/login_screen.dart
@@ -32,12 +32,7 @@ class _LoginPageState extends State<LoginPage> {
   }
 
   // 토큰 API
-  Future<void> sendDataToServer() async {
-    // 1. SharedPreferences에서 엑세스 토큰과 리프레시 토큰을 가져옵니다.
-    final prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken') ?? '';
-    final refreshToken = prefs.getString('refreshToken') ?? '';
-
+  Future<void> sendDataToServer(String accessToken, String refreshToken) async {
     // 2. 현재 플랫폼에 따라 토큰 갱신을 위한 주소를 설정합니다.
     if (Platform.isAndroid) {
       tokenAddress = 'http://10.0.2.2:9000/api/v1/auth/refresh';
@@ -103,26 +98,30 @@ class _LoginPageState extends State<LoginPage> {
 
         print('accessToken: $accessToken');
         print('로그인 성공');
-        sendDataToServer();
+        sendDataToServer(accessToken, refreshToken);
         final userRole = await searchUser(); // userRole 값을 가져옴
 
         // userRole에 따라 페이지 이동
         if (userRole == 'ROLE_OWNER') {
           print('Navigating to HomePage');
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => HomePage(accessToken: accessToken),
-            ),
-          );
+          if (context.mounted) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => HomePage(accessToken: accessToken),
+              ),
+            );
+          }
         } else if (userRole == 'ROLE_USER') {
           print('Navigating to UserHomePage');
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => UserHomePage(accessToken),
-            ),
-          );
+          if (context.mounted) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => UserHomePage(accessToken),
+              ),
+            );
+          }
         }
       } else {
         // 로그인 실패 시

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/providers/menu_provider.dart';
+import 'package:frontend/user/providers/category_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:frontend/all/screens/login_screen.dart';
@@ -28,6 +29,7 @@ void main() async {
       providers: [
         ChangeNotifierProvider(create: (_) => StoreProvider()),
         ChangeNotifierProvider(create: (_) => MenuProvider()),
+        ChangeNotifierProvider(create: (_) => CategoryProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/providers/menu_provider.dart';
 import 'package:frontend/user/providers/category_provider.dart';
+import 'package:frontend/user/providers/userMenu_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:frontend/all/screens/login_screen.dart';
@@ -30,6 +31,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => StoreProvider()),
         ChangeNotifierProvider(create: (_) => MenuProvider()),
         ChangeNotifierProvider(create: (_) => CategoryProvider()),
+        ChangeNotifierProvider(create: (_) => UserMenuProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/user/models/category_model.dart
+++ b/lib/user/models/category_model.dart
@@ -1,0 +1,13 @@
+class CategoryModel {
+  final String category;
+  final String categoryKo;
+
+  CategoryModel({
+    required this.category,
+    required this.categoryKo,
+  });
+
+  CategoryModel.fromJson(Map<String, dynamic> json)
+      : category = json['category'] ?? '',
+        categoryKo = json['categoryKo'] ?? '';
+}

--- a/lib/user/providers/category_provider.dart
+++ b/lib/user/providers/category_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/user/models/category_model.dart';
+import 'package:frontend/user/services/selectCategory_service.dart';
+
+class CategoryProvider with ChangeNotifier {
+  final List<CategoryModel> _categoryList = [];
+
+  List<CategoryModel> get categoryList => _categoryList;
+
+  Future<void> getCategory() async {
+    List<CategoryModel> getCategoryList =
+        await SelectCategoryService().getCategory();
+
+    _categoryList.clear();
+
+    for (var category in getCategoryList) {
+      _categoryList.add(category);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/user/providers/category_provider.dart
+++ b/lib/user/providers/category_provider.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/models/category_model.dart';
 import 'package:frontend/user/services/selectCategory_service.dart';
 
 class CategoryProvider with ChangeNotifier {
   final List<CategoryModel> _categoryList = [];
+  final List<StoreModel> _storeList = [];
 
   List<CategoryModel> get categoryList => _categoryList;
+  List<StoreModel> get storeList => _storeList;
 
+  // 카테고리 가져오기
   Future<void> getCategory() async {
     List<CategoryModel> getCategoryList =
         await SelectCategoryService().getCategory();
@@ -15,6 +19,19 @@ class CategoryProvider with ChangeNotifier {
 
     for (var category in getCategoryList) {
       _categoryList.add(category);
+    }
+    notifyListeners();
+  }
+
+  // 카테고리별 가게 조회
+  Future<void> getSelectCategory(String category) async {
+    List<StoreModel> getStoreList =
+        await SelectCategoryService().getSelectCategory(category);
+
+    _storeList.clear();
+
+    for (var store in getStoreList) {
+      _storeList.add(store);
     }
     notifyListeners();
   }

--- a/lib/user/providers/userMenu_provider.dart
+++ b/lib/user/providers/userMenu_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/owner/models/menu_model.dart';
+import 'package:frontend/user/services/userMenu_service.dart';
+
+class UserMenuProvider with ChangeNotifier {
+  final List<AddMenuModel> _userMenuList = [];
+
+  List<AddMenuModel> get userMenuList => _userMenuList;
+
+  // 가게별 메뉴 전체 조회
+  Future<void> fetchMenus(int storeId) async {
+    List<AddMenuModel> getUserMenuList =
+        await UserMenuService().fetchMenus(storeId);
+
+    _userMenuList.clear();
+
+    for (var userMenu in getUserMenuList) {
+      _userMenuList.add(userMenu);
+    }
+
+    notifyListeners();
+  }
+}

--- a/lib/user/screens/menuselect_screen.dart
+++ b/lib/user/screens/menuselect_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/menu_model.dart';
 import 'package:frontend/owner/models/store_model.dart';
+import 'package:frontend/user/providers/userMenu_provider.dart';
 import 'package:frontend/user/services/cart_service.dart';
-import 'package:frontend/user/services/userMenu_service.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 class UserMenuSelectPage extends StatefulWidget {
   final StoreModel store;
@@ -19,6 +20,17 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
   @override
   void initState() {
     super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Provider.of<UserMenuProvider>(context, listen: false)
+          .fetchMenus(widget.store.id);
+
+      getMenuData();
+    });
+  }
+
+  Future<List<AddMenuModel>> getMenuData() async {
+    return Provider.of<UserMenuProvider>(context, listen: false).userMenuList;
   }
 
   // 숫자 세자리마다 콤마 넣는 코드
@@ -286,7 +298,7 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
 
   Widget allMenuSection() {
     return FutureBuilder<List<AddMenuModel>>(
-      future: userMenuService().fetchMenus('${widget.store.id}'),
+      future: getMenuData(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(

--- a/lib/user/screens/menuselect_screen.dart
+++ b/lib/user/screens/menuselect_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/menu_model.dart';
 import 'package:frontend/owner/models/store_model.dart';
-import 'package:frontend/user/screens/cart_screen.dart';
 import 'package:frontend/user/services/cart_service.dart';
 import 'package:frontend/user/services/userMenu_service.dart';
 import 'package:intl/intl.dart';
@@ -9,97 +8,20 @@ import 'package:intl/intl.dart';
 class UserMenuSelectPage extends StatefulWidget {
   final StoreModel store;
   const UserMenuSelectPage({required this.store, super.key});
+
   @override
   State<UserMenuSelectPage> createState() => _UserMenuSelectPageState();
 }
 
-void showReviewsBottomSheet(BuildContext context) {
-  showModalBottomSheet(
-    context: context,
-    builder: (BuildContext context) {
-      return Container(
-          padding: const EdgeInsets.all(30.0),
-          height: 270,
-          child:
-              Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text(
-                  '리뷰 유형',
-                  style: TextStyle(
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 40),
-            // 여기에 리뷰 목록을 추가하세요.
-            Row(
-              children: [
-                const Text(
-                  '우리 배달앱 리뷰보기',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                  ),
-                ),
-                const SizedBox(width: 184),
-                ClipRRect(
-                  // 둥근 정도 조절
-                  borderRadius: BorderRadius.circular(5.0),
-                  child: SizedBox(
-                    width: 30,
-                    height: 30,
-                    child: Image.asset(
-                      'assets/images/mydelivery.png',
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 21),
-            const Divider(), // 구분선 생성
-            const SizedBox(height: 21),
-            Row(
-              children: [
-                const Text(
-                  '우리 배달앱 리뷰보기',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                  ),
-                ),
-                const SizedBox(width: 180),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(5.0),
-                  child: SizedBox(
-                    width: 30,
-                    height: 30,
-                    child: Image.asset(
-                      'assets/images/maindelivery.png',
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ]));
-    },
-  );
-}
-
 class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
-  var f = NumberFormat('###,###,###,###'); // 숫자 세자리마다 콤마 넣는 코드
+  var f = NumberFormat('###,###,###,###');
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  // 숫자 세자리마다 콤마 넣는 코드
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -390,13 +312,13 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
                     try {
                       await CartService().putCart(userMenu);
                       // 장바구니 담기에 성공하면 장바구니에 페이지로 이동
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) =>
-                              CartItemPage(widget.store, userMenu),
-                        ),
-                      );
+                      // Navigator.push(
+                      //   context,
+                      //   MaterialPageRoute(
+                      //     builder: (context) =>
+                      //         CartItemPage(widget.store, userMenu),
+                      //   ),
+                      // );
                     } catch (e) {
                       // 장바구니에 담은 경우 다른 가게의 메뉴를 담을려고 할 때 경고창 구현
                       showDialog(
@@ -508,4 +430,89 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
       },
     );
   }
+}
+
+void showReviewsBottomSheet(BuildContext context) {
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return Container(
+          padding: const EdgeInsets.all(30.0),
+          height: 270,
+          child:
+              Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '리뷰 유형',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 40),
+            // 여기에 리뷰 목록을 추가하세요.
+            Row(
+              children: [
+                const Text(
+                  '우리 배달앱 리뷰보기',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(width: 184),
+                ClipRRect(
+                  // 둥근 정도 조절
+                  borderRadius: BorderRadius.circular(5.0),
+                  child: SizedBox(
+                    width: 30,
+                    height: 30,
+                    child: Image.asset(
+                      'assets/images/mydelivery.png',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 21),
+            const Divider(), // 구분선 생성
+            const SizedBox(height: 21),
+            Row(
+              children: [
+                const Text(
+                  '우리 배달앱 리뷰보기',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(width: 180),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(5.0),
+                  child: SizedBox(
+                    width: 30,
+                    height: 30,
+                    child: Image.asset(
+                      'assets/images/maindelivery.png',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ]));
+    },
+  );
 }

--- a/lib/user/screens/storeselect_screen.dart
+++ b/lib/user/screens/storeselect_screen.dart
@@ -5,29 +5,29 @@ import 'package:frontend/user/screens/menuselect_screen.dart';
 import 'package:frontend/user/services/selectCategory_service.dart';
 import 'package:provider/provider.dart';
 
-class UserMenuPage extends StatefulWidget {
-  final String category; // 선택된 카테고리
-  const UserMenuPage({required this.category, super.key});
+class StoreSelectPage extends StatefulWidget {
+  const StoreSelectPage({
+    super.key,
+  });
 
   @override
-  State<UserMenuPage> createState() => _UserMenuPageState();
+  State<StoreSelectPage> createState() => _StoreSelectPageState();
 }
 
-class _UserMenuPageState extends State<UserMenuPage> {
+class _StoreSelectPageState extends State<StoreSelectPage> {
   int selectedButtonIndex = -1;
   double rating = 1.0; // 별점
   double deliveryFee = 0; // 배달비
   double minOrder = 3000; // 최소주문
-  List<StoreModel> stores = [];
   final SelectCategoryService selectCategoryService = SelectCategoryService();
 
   @override
   void initState() {
     super.initState(); // initState 메서드를 호출하여 초기화
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await Provider.of<CategoryProvider>(context, listen: false)
-          .getSelectCategory(widget.category);
-    });
+    // WidgetsBinding.instance.addPostFrameCallback((_) async {
+    //   await Provider.of<CategoryProvider>(context, listen: false)
+    //       .getSelectCategory(widget.category);
+    // });
   }
 
   void handleButtonSelection(int index) {
@@ -667,8 +667,8 @@ class _UserMenuPageState extends State<UserMenuPage> {
                       return const Center(child: CircularProgressIndicator());
                     } else if (snapshot.hasError) {
                       return Center(child: Text('Error: ${snapshot.error}'));
-                    } else if (!snapshot.hasData) {
-                      return const Center(child: Text('No stores found.'));
+                    } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                      return const Center(child: Text('등록된 가게가 없습니다.'));
                     } else {
                       return ListView.builder(
                         itemCount: snapshot.data!.length,
@@ -676,7 +676,9 @@ class _UserMenuPageState extends State<UserMenuPage> {
                           final store = snapshot.data![index];
 
                           return GestureDetector(
-                            onTap: () {
+                            onTap: () async {
+                              print('가게 아이디: ${store.id}');
+
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(

--- a/lib/user/screens/storeselect_screen.dart
+++ b/lib/user/screens/storeselect_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/store_model.dart';
+import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/screens/menuselect_screen.dart';
 import 'package:frontend/user/services/selectCategory_service.dart';
+import 'package:provider/provider.dart';
 
 class UserMenuPage extends StatefulWidget {
   final String category; // 선택된 카테고리
@@ -22,7 +24,10 @@ class _UserMenuPageState extends State<UserMenuPage> {
   @override
   void initState() {
     super.initState(); // initState 메서드를 호출하여 초기화
-    fetchStoresByCategory(widget.category); // 카테고리 기반으로 가게 정보를 가져오는 메서드 호출
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Provider.of<CategoryProvider>(context, listen: false)
+          .getSelectCategory(widget.category);
+    });
   }
 
   void handleButtonSelection(int index) {
@@ -40,21 +45,8 @@ class _UserMenuPageState extends State<UserMenuPage> {
     });
   }
 
-  // 카테고리별 가게 정보를 가져오는 메서드
-  Future<void> fetchStoresByCategory(String category) async {
-    try {
-      // SelectCategoryService 인스턴스를 통해 카테고리에 해당하는 가게 정보를 가져옴
-      List<StoreModel> fetchedStores =
-          await selectCategoryService.getSelectCategory(category);
-
-      // 상태를 업데이트하여 가져온 가게 정보를 stores 리스트에 저장
-      setState(() {
-        stores = fetchedStores;
-      });
-    } catch (e) {
-      // 예외 발생 시 에러 메시지 출력
-      print('Error fetching stores: $e');
-    }
+  Future<List<StoreModel>> getStoreData() async {
+    return Provider.of<CategoryProvider>(context, listen: false).storeList;
   }
 
   Widget buildBottomSheet(BuildContext context) {
@@ -668,110 +660,129 @@ class _UserMenuPageState extends State<UserMenuPage> {
 
               // 가게 리스트
               Expanded(
-                child: ListView.builder(
-                  itemCount: stores.length,
-                  itemBuilder: (context, index) {
-                    final store = stores[index];
-                    return GestureDetector(
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => UserMenuSelectPage(
-                              store: store,
-                            ),
-                          ),
-                        );
-                      },
-                      child: Hero(
-                        tag: store.id, // 가게 아이디로 태그 설정
-                        child: Container(
-                          margin: const EdgeInsets.only(bottom: 18),
-                          width: double.infinity,
-                          height: 132,
-                          padding: const EdgeInsets.only(right: 20.0),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFFFFFFF),
-                            borderRadius: BorderRadius.circular(15.0),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black.withOpacity(0.25),
-                                offset: const Offset(0, 4),
-                                blurRadius: 4.0,
-                              ),
-                            ],
-                          ),
-                          child: Row(
-                            children: [
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(15.0),
-                                child: SizedBox(
-                                  width: MediaQuery.of(context).size.width / 3,
-                                  height: 132,
-                                  child: Image.asset(
-                                    'assets/images/deliverylogo.png',
-                                    fit: BoxFit.cover,
-                                    errorBuilder: (context, error, stackTrace) {
-                                      return const Center(
-                                        child: Icon(
-                                          Icons.error,
-                                          color: Colors.red,
-                                          size: 50,
-                                        ),
-                                      );
-                                    },
+                child: FutureBuilder<List<StoreModel>>(
+                  future: getStoreData(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Center(child: CircularProgressIndicator());
+                    } else if (snapshot.hasError) {
+                      return Center(child: Text('Error: ${snapshot.error}'));
+                    } else if (!snapshot.hasData) {
+                      return const Center(child: Text('No stores found.'));
+                    } else {
+                      return ListView.builder(
+                        itemCount: snapshot.data!.length,
+                        itemBuilder: (context, index) {
+                          final store = snapshot.data![index];
+
+                          return GestureDetector(
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => UserMenuSelectPage(
+                                    store: store,
                                   ),
                                 ),
-                              ),
-                              Expanded(
-                                child: Padding(
-                                  padding: const EdgeInsets.only(left: 16.0),
-                                  child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        store.name,
-                                        style: const TextStyle(
-                                          fontSize: 22,
-                                          fontWeight: FontWeight.bold,
-                                          color: Colors.black,
+                              );
+                            },
+                            child: Hero(
+                              tag: store.id, // 가게 아이디로 태그 설정
+                              child: Container(
+                                margin: const EdgeInsets.only(bottom: 18),
+                                width: double.infinity,
+                                height: 132,
+                                padding: const EdgeInsets.only(right: 20.0),
+                                decoration: BoxDecoration(
+                                  color: const Color(0xFFFFFFFF),
+                                  borderRadius: BorderRadius.circular(15.0),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.black.withOpacity(0.25),
+                                      offset: const Offset(0, 4),
+                                      blurRadius: 4.0,
+                                    ),
+                                  ],
+                                ),
+                                child: Row(
+                                  children: [
+                                    ClipRRect(
+                                      borderRadius: BorderRadius.circular(15.0),
+                                      child: SizedBox(
+                                        width:
+                                            MediaQuery.of(context).size.width /
+                                                3,
+                                        height: 132,
+                                        child: Image.asset(
+                                          'assets/images/deliverylogo.png',
+                                          fit: BoxFit.cover,
+                                          errorBuilder:
+                                              (context, error, stackTrace) {
+                                            return const Center(
+                                              child: Icon(
+                                                Icons.error,
+                                                color: Colors.red,
+                                                size: 50,
+                                              ),
+                                            );
+                                          },
                                         ),
                                       ),
-                                      const SizedBox(height: 8),
-                                      Text(
-                                        '최소 주문 ${store.minOrderPrice}원',
-                                        style: const TextStyle(
-                                          fontSize: 12,
-                                          color: Color(0xFF808080),
-                                        ),
-                                      ),
-                                      const SizedBox(height: 4),
-                                      const Row(
-                                        children: [
-                                          Icon(Icons.star,
-                                              color: Color(0xFFDFB300),
-                                              size: 15),
-                                          SizedBox(width: 4),
-                                          Text(
-                                            '4.5',
-                                            style: TextStyle(
-                                              fontSize: 12,
-                                              color: Colors.black,
+                                    ),
+                                    Expanded(
+                                      child: Padding(
+                                        padding:
+                                            const EdgeInsets.only(left: 16.0),
+                                        child: Column(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              store.name,
+                                              style: const TextStyle(
+                                                fontSize: 22,
+                                                fontWeight: FontWeight.bold,
+                                                color: Colors.black,
+                                              ),
                                             ),
-                                          ),
-                                        ],
+                                            const SizedBox(height: 8),
+                                            Text(
+                                              '최소 주문 ${store.minOrderPrice}원',
+                                              style: const TextStyle(
+                                                fontSize: 12,
+                                                color: Color(0xFF808080),
+                                              ),
+                                            ),
+                                            const SizedBox(height: 4),
+                                            const Row(
+                                              children: [
+                                                Icon(Icons.star,
+                                                    color: Color(0xFFDFB300),
+                                                    size: 15),
+                                                SizedBox(width: 4),
+                                                Text(
+                                                  '4.5',
+                                                  style: TextStyle(
+                                                    fontSize: 12,
+                                                    color: Colors.black,
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          ],
+                                        ),
                                       ),
-                                    ],
-                                  ),
+                                    ),
+                                  ],
                                 ),
                               ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    );
+                            ),
+                          );
+                        },
+                      );
+                    }
                   },
                 ),
               ),

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -1,9 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/models/category_model.dart';
 import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/screens/complete_screen.dart';
-import 'package:frontend/user/screens/storeselect_screen.dart';
+import 'package:frontend/user/screens/storeSelect_screen.dart';
 import 'package:frontend/user/screens/userAddress_screen.dart';
 import 'package:frontend/user/services/selectCategory_service.dart';
 import 'package:frontend/user/services/userStore_service.dart';
@@ -91,6 +92,10 @@ class _UserHomePageState extends State<UserHomePage> {
     }
 
     return stores;
+  }
+
+  Future<List<CategoryModel>> getCategoryData() async {
+    return Provider.of<CategoryProvider>(context, listen: false).categoryList;
   }
 
   @override
@@ -366,7 +371,7 @@ class _UserHomePageState extends State<UserHomePage> {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 19.0),
-                  child: (userAddress == '주소를 설정하세요')
+                  child: (userAddress == 'd')
                       ? const Center(
                           child: Text(
                             '주소를 설정해주세요',
@@ -387,15 +392,21 @@ class _UserHomePageState extends State<UserHomePage> {
                                 bool isDeliveryLogo =
                                     categories[index].category == 'CSAI';
                                 return GestureDetector(
-                                  onTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) => UserMenuPage(
-                                          category: categories[index].category,
+                                  onTap: () async {
+                                    await Provider.of<CategoryProvider>(context,
+                                            listen: false)
+                                        .getSelectCategory(
+                                            categories[index].category);
+
+                                    if (context.mounted) {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              const StoreSelectPage(),
                                         ),
-                                      ),
-                                    );
+                                      );
+                                    }
                                     print(
                                         "Food item ${categories[index].category} clicked!"); // Example
                                   },

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -41,9 +41,6 @@ class _UserHomePageState extends State<UserHomePage> {
         }
       });
     });
-    // fetchCategories(); // 카테고리 정보를 가져오는 메서드를 호출하여 초기화 시 데이터 로드
-    futureStores =
-        UserStoreService().getManyStores(); // 모든 가게 리스트를 futureStores에 저장
   }
 
 // 카테고리 정보를 서버에서 가져오는 메서드
@@ -364,75 +361,89 @@ class _UserHomePageState extends State<UserHomePage> {
                 ),
               ),
               const SizedBox(height: 20),
+
               // 음식 메뉴
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 19.0),
-                  child: categories.isEmpty
-                      ? const Center(child: CircularProgressIndicator())
-                      : GridView.count(
-                          crossAxisCount: 3, // 3 x 3
-                          crossAxisSpacing: 10,
-                          mainAxisSpacing: 10,
-                          children: List.generate(categories.length, (index) {
-                            bool isDeliveryLogo =
-                                categories[index].category == 'CSAI';
-                            return GestureDetector(
-                              onTap: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => UserMenuPage(
-                                      category: categories[index].category,
+                  child: (userAddress == '주소를 설정하세요')
+                      ? const Center(
+                          child: Text(
+                            '주소를 설정해주세요',
+                            style: TextStyle(
+                              fontSize: 20,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        )
+                      : categories.isEmpty
+                          ? const Center(child: CircularProgressIndicator())
+                          : GridView.count(
+                              crossAxisCount: 3, // 3 x 3
+                              crossAxisSpacing: 10,
+                              mainAxisSpacing: 10,
+                              children:
+                                  List.generate(categories.length, (index) {
+                                bool isDeliveryLogo =
+                                    categories[index].category == 'CSAI';
+                                return GestureDetector(
+                                  onTap: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => UserMenuPage(
+                                          category: categories[index].category,
+                                        ),
+                                      ),
+                                    );
+                                    print(
+                                        "Food item ${categories[index].category} clicked!"); // Example
+                                  },
+                                  child: Container(
+                                    padding: const EdgeInsets.all(8.0),
+                                    decoration: BoxDecoration(
+                                      color: Colors.white,
+                                      borderRadius: BorderRadius.circular(10.0),
+                                      boxShadow: [
+                                        BoxShadow(
+                                          color: const Color(0xFF374AA3)
+                                              .withOpacity(0.5),
+                                          blurRadius: 4,
+                                          offset: const Offset(0, 4),
+                                        ),
+                                      ],
+                                    ),
+                                    child: Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: [
+                                        Image.asset(
+                                          'assets/images/${categories[index].category.toLowerCase()}.png',
+                                          height: isDeliveryLogo ? 108 : 50,
+                                          width: isDeliveryLogo ? 108 : 50,
+                                        ),
+                                        if (!isDeliveryLogo) ...[
+                                          const SizedBox(height: 10),
+                                          Text(
+                                            // categories[index].category,
+                                            categoryTranslations[
+                                                    categories[index]
+                                                        .category] ??
+                                                categories[index].category,
+
+                                            style: const TextStyle(
+                                              color: Colors.black,
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ],
+                                      ],
                                     ),
                                   ),
                                 );
-                                print(
-                                    "Food item ${categories[index].category} clicked!"); // Example
-                              },
-                              child: Container(
-                                padding: const EdgeInsets.all(8.0),
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(10.0),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: const Color(0xFF374AA3)
-                                          .withOpacity(0.5),
-                                      blurRadius: 4,
-                                      offset: const Offset(0, 4),
-                                    ),
-                                  ],
-                                ),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Image.asset(
-                                      'assets/images/${categories[index].category.toLowerCase()}.png',
-                                      height: isDeliveryLogo ? 108 : 50,
-                                      width: isDeliveryLogo ? 108 : 50,
-                                    ),
-                                    if (!isDeliveryLogo) ...[
-                                      const SizedBox(height: 10),
-                                      Text(
-                                        // categories[index].category,
-                                        categoryTranslations[
-                                                categories[index].category] ??
-                                            categories[index].category,
-
-                                        style: const TextStyle(
-                                          color: Colors.black,
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
-                                    ],
-                                  ],
-                                ),
-                              ),
-                            );
-                          }),
-                        ),
+                              }),
+                            ),
                 ),
               ),
             ],

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/store_model.dart';
+import 'package:frontend/user/models/category_model.dart';
+import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/screens/complete_screen.dart';
 import 'package:frontend/user/screens/storeselect_screen.dart';
 import 'package:frontend/user/screens/userAddress_screen.dart';
 import 'package:frontend/user/services/selectCategory_service.dart';
 import 'package:frontend/user/services/userStore_service.dart';
 import 'package:frontend/user/widgets/menuSearch_widget.dart';
+import 'package:provider/provider.dart';
 
 class UserHomePage extends StatefulWidget {
   final String accessToken;
@@ -16,7 +19,7 @@ class UserHomePage extends StatefulWidget {
 }
 
 class _UserHomePageState extends State<UserHomePage> {
-  List<StoreModel> categories = [];
+  List<CategoryModel> categories = [];
   late Future<List<StoreModel>> futureStores;
 
   TextEditingController searchController = TextEditingController();
@@ -26,24 +29,36 @@ class _UserHomePageState extends State<UserHomePage> {
   @override
   void initState() {
     super.initState();
-    fetchCategories(); // 카테고리 정보를 가져오는 메서드를 호출하여 초기화 시 데이터 로드
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Provider.of<CategoryProvider>(context, listen: false).getCategory();
+
+      setState(() {
+        List<CategoryModel> getCategories =
+            Provider.of<CategoryProvider>(context, listen: false).categoryList;
+
+        for (var category in getCategories) {
+          categories.add(category);
+        }
+      });
+    });
+    // fetchCategories(); // 카테고리 정보를 가져오는 메서드를 호출하여 초기화 시 데이터 로드
     futureStores =
         UserStoreService().getManyStores(); // 모든 가게 리스트를 futureStores에 저장
   }
 
 // 카테고리 정보를 서버에서 가져오는 메서드
-  void fetchCategories() async {
-    // SelectCategoryService 인스턴스를 생성
-    SelectCategoryService categoryService = SelectCategoryService();
+  // void fetchCategories() async {
+  //   // SelectCategoryService 인스턴스를 생성
+  //   SelectCategoryService categoryService = SelectCategoryService();
 
-    // categoryService를 사용하여 카테고리 정보를 비동기적으로 가져옴
-    List<StoreModel> fetchedCategories = await categoryService.getCategory(0);
+  //   // categoryService를 사용하여 카테고리 정보를 비동기적으로 가져옴
+  //   List<StoreModel> fetchedCategories = await categoryService.getCategory(0);
 
-    // 상태를 업데이트하여 가져온 카테고리 정보를 categories 리스트에 저장
-    setState(() {
-      categories = fetchedCategories;
-    });
-  }
+  //   // 상태를 업데이트하여 가져온 카테고리 정보를 categories 리스트에 저장
+  //   setState(() {
+  //     categories = fetchedCategories;
+  //   });
+  // }
 
   void filterSearchResults(String query) {}
 

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/models/category_model.dart';
@@ -6,7 +5,6 @@ import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/screens/complete_screen.dart';
 import 'package:frontend/user/screens/storeSelect_screen.dart';
 import 'package:frontend/user/screens/userAddress_screen.dart';
-import 'package:frontend/user/services/selectCategory_service.dart';
 import 'package:frontend/user/services/userStore_service.dart';
 import 'package:frontend/user/widgets/menuSearch_widget.dart';
 import 'package:provider/provider.dart';

--- a/lib/user/services/selectCategory_service.dart
+++ b/lib/user/services/selectCategory_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
 import 'package:frontend/owner/models/store_model.dart';
+import 'package:frontend/user/models/category_model.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -8,13 +9,10 @@ class SelectCategoryService {
   late String serverAddress;
 
   // 카테고리 가져오기 API
-  Future<List<StoreModel>> getCategory(int selectedCategoryIndex) async {
+  Future<List<CategoryModel>> getCategory() async {
     // SharedPreferences에서 액세스 토큰을 가져옴
     final prefs = await SharedPreferences.getInstance();
     final accessToken = prefs.getString('accessToken') ?? '';
-
-    // 카테고리 인스턴스를 저장할 리스트를 생성
-    List<StoreModel> categoryInstance = [];
 
     // 현재 플랫폼에 따라 서버 주소 설정
     if (Platform.isAndroid) {
@@ -40,33 +38,22 @@ class SelectCategoryService {
         // 디코딩된 응답을 JSON 형태로 변환
         final dynamic jsonResponse = jsonDecode(utf8Response);
 
-        // jsonResponse가 Map이고 data 필드가 List일 경우
-        if (jsonResponse is Map && jsonResponse['data'] is List) {
-          final List<dynamic> categories = jsonResponse['data'];
-          print('JSON 데이터: $categories');
+        final dataResponse = jsonResponse['data'];
+        print('카테고리 조회 성공: $dataResponse');
 
-          // 각 카테고리를 SelectCategoryModel 인스턴스로 변환하여 리스트에 추가
-          for (var category in categories) {
-            categoryInstance.add(StoreModel.fromJson(category));
-          }
-
-          print('조회 성공 $categoryInstance');
-          return categoryInstance;
-        } else {
-          // 응답이 예상과 다를 경우
-          print('응답이 예상과 다름: $jsonResponse');
-          return [];
+        List<CategoryModel> categoryList = [];
+        // 각 카테고리를 SelectCategoryModel 인스턴스로 변환하여 리스트에 추가
+        for (var data in dataResponse) {
+          categoryList.add(CategoryModel.fromJson(data));
         }
+
+        return categoryList;
       } else {
-        // 요청 실패 시
-        print('조회 실패: ${response.statusCode}');
-        print('응답 본문: ${response.body}');
-        return [];
+        throw Exception('조회 실패: ${response.statusCode} - ${response.body}');
       }
     } catch (e) {
       // 예외 발생 시
-      print('예외 발생: $e');
-      return [];
+      throw Exception('예외 발생: $e');
     }
   }
 

--- a/lib/user/services/selectCategory_service.dart
+++ b/lib/user/services/selectCategory_service.dart
@@ -59,9 +59,6 @@ class SelectCategoryService {
 
   // 카테고리별 가게 조회 API
   Future<List<StoreModel>> getSelectCategory(String category) async {
-    // 가게 인스턴스를 저장할 리스트 생성
-    List<StoreModel> categorySelectInstance = [];
-
     // SharedPreferences에서 토큰을 가져옵니다.
     final prefs = await SharedPreferences.getInstance();
     final accessToken = prefs.getString('accessToken') ?? '';
@@ -91,47 +88,25 @@ class SelectCategoryService {
         // 서버 응답을 UTF-8로 디코딩
         final utf8Response = utf8.decode(response.bodyBytes);
         // 디코딩된 응답을 JSON 형태로 변환
-        final dynamic jsonResponse = jsonDecode(utf8Response);
+        final jsonResponse = jsonDecode(utf8Response);
+        final dataResponse = jsonResponse['data'];
 
-        // jsonResponse가 Map이고 data 필드가 List일 경우
-        if (jsonResponse is Map && jsonResponse['data'] is List) {
-          final List<dynamic> stores = jsonResponse['data'];
-          print('JSON 데이터: $stores');
+        List<StoreModel> storeList = [];
 
-          // 각 가게를 SelectCategoryModel 인스턴스로 변환하여 리스트에 추가
-          for (var store in stores) {
-            categorySelectInstance.add(StoreModel.fromJson(store));
-          }
-
-          print('조회 성공 $categorySelectInstance');
-          return categorySelectInstance;
-        } else if (jsonResponse is List) {
-          // jsonResponse가 List일 경우
-          final List<dynamic> stores = jsonResponse;
-          print('JSON 데이터: $stores');
-
-          // 각 가게를 SelectCategoryModel 인스턴스로 변환하여 리스트에 추가
-          for (var store in stores) {
-            categorySelectInstance.add(StoreModel.fromJson(store));
-          }
-
-          print('조회 성공 $categorySelectInstance');
-          return categorySelectInstance;
-        } else {
-          // 응답이 예상과 다를 경우
-          print('응답이 예상과 다름: $jsonResponse');
-          return [];
+        for (var store in dataResponse) {
+          storeList.add(StoreModel.fromJson(store));
         }
+
+        print('카테고리별 가게 조회 성공: $dataResponse');
+
+        return storeList;
       } else {
         // 요청 실패 시
-        print('조회 실패: ${response.statusCode}');
-        print('응답 본문: ${response.body}');
-        return [];
+        throw Exception('조회 실패 : ${response.statusCode} - ${response.body}');
       }
     } catch (e) {
       // 예외 발생 시
-      print('예외 발생: $e');
-      return [];
+      throw Exception('예외 발생: $e');
     }
   }
 }

--- a/lib/user/services/userMenu_service.dart
+++ b/lib/user/services/userMenu_service.dart
@@ -3,11 +3,11 @@ import 'dart:io' show Platform;
 import 'package:frontend/owner/models/menu_model.dart';
 import 'package:http/http.dart' as http;
 
-class userMenuService {
+class UserMenuService {
   String serverAddress = '';
 
-  Future<List<AddMenuModel>> fetchMenus(String storeId) async {
-    List<AddMenuModel> userMenuInstance = [];
+  // 가게별 메뉴 전체 조회
+  Future<List<AddMenuModel>> fetchMenus(int storeId) async {
     if (Platform.isAndroid) {
       serverAddress = 'http://10.0.2.2:9000/api/v1/$storeId/menus';
     } else if (Platform.isIOS) {
@@ -21,23 +21,20 @@ class userMenuService {
         final utf8Response = utf8.decode(response.bodyBytes);
         final dynamic jsonResponse = jsonDecode(utf8Response);
 
-        if (jsonResponse is Map && jsonResponse['data'] is List) {
-          final List<dynamic> userMenus = jsonResponse['data'];
-          print('JSON 데이터: $userMenus');
+        final dataResponse = jsonResponse['data'];
+        List<AddMenuModel> userMenuList = [];
 
-          for (var menu in userMenus) {
-            userMenuInstance.add(AddMenuModel.fromJson(menu));
-          }
+        for (var data in dataResponse) {
+          userMenuList.add(AddMenuModel.fromJson(data));
         }
-        print('조회 성공: $userMenuInstance');
-        return userMenuInstance;
+
+        print('가게별 메뉴 조회 성공: $dataResponse');
+        return userMenuList;
       } else {
-        print('조회 실패');
-        return [];
+        throw Exception('조회 실패: ${response.statusCode} - ${response.body}');
       }
     } catch (e) {
-      print(e.toString());
-      return [];
+      throw Exception(e.toString());
     }
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#117

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 카테고리 가져오기 api 및 provider 구현
- 카테고리 모델 생성
- 카테고리 가져오기의 응답데이터를 가져와 provider의 카테고리 저장 변수에 저장
- userHome에서 addPostFrameCallback으로 카테고리 가져오기 api 호출 후 caregories 변수에 저장
### 카테고리별 가게 조회 API 및 Provider 구현
### 카테고리 가져오기 및 카테고리별 가게 조회 api 구현
- 사용자 홈 화면에 카테고리 가져오는 api를 호출해 categories 변수에 저장
- 가게 상세 페이지로 이동할 때 hero 위젯을 사용해서 store 데이터를 전달해 구현
### 가게별 메뉴 전체 조회 api & provider 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
