### PR TITLE
[Feat(user)/#119] 장바구니 담기 및 조회, 주문하기 api 구현

### DIFF
--- a/lib/all/screens/login_screen.dart
+++ b/lib/all/screens/login_screen.dart
@@ -108,7 +108,7 @@ class _LoginPageState extends State<LoginPage> {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => HomePage(accessToken: accessToken),
+                builder: (context) => const HomePage(),
               ),
             );
           }
@@ -118,7 +118,7 @@ class _LoginPageState extends State<LoginPage> {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => UserHomePage(accessToken),
+                builder: (context) => const UserHomePage(),
               ),
             );
           }

--- a/lib/all/screens/signup_screen.dart
+++ b/lib/all/screens/signup_screen.dart
@@ -108,6 +108,7 @@ class _SignupPageState extends State<SignupPage> {
     );
   }
 
+  // 회원가입 API
   Future handleSignUp(String nickname, String email, String userId,
       String password, String userRole) async {
     try {
@@ -317,7 +318,7 @@ class _SignupPageState extends State<SignupPage> {
                       ),
                     ),
                     child: const Text(
-                      'Sign up',
+                      '회원가입',
                       style: TextStyle(
                         color: Colors.white,
                         fontWeight: FontWeight.bold,

--- a/lib/all/services/order_service.dart
+++ b/lib/all/services/order_service.dart
@@ -9,8 +9,8 @@ class OrderService {
   String serverAddress = '';
   int? currentStoreId; // 현재 장바구니에 담긴 가게 ID를 저장
 
-  // 주문 api
-  Future<int> order(
+  // 주문
+  Future<void> order(
     String? orderStatus,
     int? storeId,
     int? totalPrice,
@@ -46,13 +46,8 @@ class OrderService {
 
       if (response.statusCode == 200) {
         print('주문 성공: ${response.body}');
-        final responseBody = jsonDecode(response.body);
-        final userId = responseBody['userId'];
-
-        return userId;
       } else {
-        print('주문 실패');
-        return 0;
+        print('주문 실패: ${response.body}');
       }
     } catch (e) {
       print('Error: $e');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:frontend/user/providers/cart_provider.dart';
 import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/providers/userInfo_provider.dart';
 import 'package:frontend/user/providers/userMenu_provider.dart';
+import 'package:frontend/user/providers/userStore_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:frontend/all/screens/login_screen.dart';
@@ -36,6 +37,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => UserMenuProvider()),
         ChangeNotifierProvider(create: (_) => UserInfoProvider()),
         ChangeNotifierProvider(create: (_) => CartProvider()),
+        ChangeNotifierProvider(create: (_) => UserStoreProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/providers/menu_provider.dart';
 import 'package:frontend/user/providers/category_provider.dart';
+import 'package:frontend/user/providers/userInfo_provider.dart';
 import 'package:frontend/user/providers/userMenu_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -32,6 +33,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => MenuProvider()),
         ChangeNotifierProvider(create: (_) => CategoryProvider()),
         ChangeNotifierProvider(create: (_) => UserMenuProvider()),
+        ChangeNotifierProvider(create: (_) => UserInfoProvider()),
       ],
       child: const MyApp(),
     ),
@@ -46,6 +48,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     // snackbar를 사용하기 위해 GetX 컨텍스트 초기화를 위해 작성
     return const GetMaterialApp(
+      debugShowCheckedModeBanner: false,
       home: LoginPage(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/providers/menu_provider.dart';
+import 'package:frontend/user/providers/cart_provider.dart';
 import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/providers/userInfo_provider.dart';
 import 'package:frontend/user/providers/userMenu_provider.dart';
@@ -34,6 +35,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => CategoryProvider()),
         ChangeNotifierProvider(create: (_) => UserMenuProvider()),
         ChangeNotifierProvider(create: (_) => UserInfoProvider()),
+        ChangeNotifierProvider(create: (_) => CartProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/owner/screens/home_screen.dart
+++ b/lib/owner/screens/home_screen.dart
@@ -9,15 +9,13 @@ import 'package:frontend/owner/screens/register_store.dart';
 import 'package:frontend/owner/screens/receipt_screen.dart';
 import 'package:frontend/owner/screens/review_screen.dart';
 import 'package:frontend/owner/screens/store_screen.dart';
-import 'package:frontend/owner/services/store_service.dart';
 import 'package:frontend/owner/widgets/circle_widget.dart';
 import 'package:frontend/owner/widgets/current_widget.dart';
 import 'package:frontend/owner/widgets/menuItem_widget.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
-  final String accessToken;
-  const HomePage({required this.accessToken, super.key});
+  const HomePage({super.key});
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -179,8 +177,8 @@ class _HomePageState extends State<HomePage> {
                         final refreshResult = await Navigator.push(
                           context,
                           MaterialPageRoute(
-                              builder: (context) => RegisterStorePage(
-                                  selectedStore, widget.accessToken)),
+                              builder: (context) =>
+                                  RegisterStorePage(selectedStore)),
                         );
                         if (context.mounted) {
                           Navigator.pop(context, refreshResult);

--- a/lib/owner/screens/home_screen.dart
+++ b/lib/owner/screens/home_screen.dart
@@ -511,6 +511,7 @@ class _HomePageState extends State<HomePage> {
                             ),
                             GestureDetector(
                               onTap: () {
+                                print('storeId: $storeId');
                                 // 가게 선택하지 않을 경우 못 들어가게 설정
                                 if (selectedStore.isNotEmpty) {
                                   Navigator.push(

--- a/lib/owner/screens/register_store.dart
+++ b/lib/owner/screens/register_store.dart
@@ -8,9 +8,8 @@ import 'package:image_picker/image_picker.dart';
 class RegisterStorePage extends StatefulWidget {
   // home_screen.dart에서 selectedStore 값을 가져옴
   final String selectedStore;
-  final String accessToken;
 
-  const RegisterStorePage(this.selectedStore, this.accessToken, {super.key});
+  const RegisterStorePage(this.selectedStore, {super.key});
 
   @override
   State<RegisterStorePage> createState() => _RegisterStorePageState();
@@ -615,7 +614,6 @@ class _RegisterStorePageState extends State<RegisterStorePage> {
                         openInitialTime,
                         closeInitialTime,
                         _menuImage!,
-                        widget.accessToken,
                       );
 
                       Navigator.pop(

--- a/lib/owner/screens/store_screen.dart
+++ b/lib/owner/screens/store_screen.dart
@@ -329,7 +329,7 @@ class _StorePageState extends State<StorePage> {
                                 ),
                                 child: Center(
                                   child: Image.network(
-                                    store['storeImageUrl'],
+                                    store['storeImageUrl'] ?? '',
                                     width: 100,
                                     height: 100,
                                   ),

--- a/lib/owner/services/store_service.dart
+++ b/lib/owner/services/store_service.dart
@@ -67,7 +67,6 @@ class StoreService {
     TimeOfDay openTime,
     TimeOfDay closeTime,
     File file,
-    String? accessToken,
   ) async {
     final Map<String, String> categoryMapping = {
       '햄버거': 'HAMBURGER',
@@ -79,6 +78,9 @@ class StoreService {
       '일식': 'JAPANESEFOOD',
       '치킨': 'CHICKEN',
     };
+
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken') ?? '';
 
     try {
       String serverAddress;

--- a/lib/user/models/cartMenu_model.dart
+++ b/lib/user/models/cartMenu_model.dart
@@ -16,13 +16,4 @@ class CartMenuModel {
         menuName = json['menuName'] ?? '', // JSON 키를 'menuName'으로 수정
         imageUrl = json['imageUrl'] ?? '', // JSON 키를 'imageUrl'로 수정
         price = json['price'] ?? 0;
-
-  Map<String, dynamic> toJson() {
-    return {
-      'menuId': menuId, // JSON 키를 'menuId'로 수정
-      'menuName': menuName, // JSON 키를 'menuName'으로 수정
-      'imageUrl': imageUrl, // JSON 키를 'imageUrl'로 수정
-      'price': price
-    };
-  }
 }

--- a/lib/user/providers/cart_provider.dart
+++ b/lib/user/providers/cart_provider.dart
@@ -6,14 +6,13 @@ class CartProvider with ChangeNotifier {
 
   Map<String, dynamic> get cart => _cart;
 
-  Future<Map<String, dynamic>> getCart() async {
+  // 장바구니 조회
+  Future<void> getCart() async {
     Map<String, dynamic> getCart = await CartService().getCart();
 
     _cart.clear();
 
     _cart = getCart;
     notifyListeners();
-
-    return _cart;
   }
 }

--- a/lib/user/providers/cart_provider.dart
+++ b/lib/user/providers/cart_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/user/services/cart_service.dart';
+
+class CartProvider with ChangeNotifier {
+  Map<String, dynamic> _cart = {};
+
+  Map<String, dynamic> get cart => _cart;
+
+  Future<Map<String, dynamic>> getCart() async {
+    Map<String, dynamic> getCart = await CartService().getCart();
+
+    _cart.clear();
+
+    _cart = getCart;
+    notifyListeners();
+
+    return _cart;
+  }
+}

--- a/lib/user/providers/userInfo_provider.dart
+++ b/lib/user/providers/userInfo_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/user/services/userInfo_service.dart';
+
+class UserInfoProvider with ChangeNotifier {
+  Map<String, dynamic> _userInfo = {};
+
+  Map<String, dynamic> get userInfo => _userInfo;
+
+  // 유저 정보 검색
+  Future<void> fetchUserInfo() async {
+    Map<String, dynamic> getUserInfo = await UserInfoService().fetchUserInfo();
+
+    _userInfo.clear();
+
+    _userInfo = getUserInfo;
+    notifyListeners();
+  }
+}

--- a/lib/user/providers/userStore_provider.dart
+++ b/lib/user/providers/userStore_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/user/services/userStore_service.dart';
+
+class UserStoreProvider with ChangeNotifier {
+  Map<String, dynamic> _store = {};
+
+  Map<String, dynamic> get store => _store;
+
+  // 가게 조회
+  Future<void> getStore(int storeId) async {
+    try {
+      Map<String, dynamic> getStore =
+          await UserStoreService().getStore(storeId);
+
+      _store = getStore;
+
+      notifyListeners();
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+}

--- a/lib/user/screens/cart_screen.dart
+++ b/lib/user/screens/cart_screen.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/owner/models/menu_model.dart';
-import 'package:frontend/owner/models/store_model.dart';
-import 'package:frontend/user/providers/cart_provider.dart';
-import 'package:frontend/user/screens/userOrder_screen.dart';
+import 'package:frontend/user/models/cartMenu_model.dart';
+import 'package:frontend/user/screens/userHome_screen.dart';
+import 'package:frontend/user/services/cart_service.dart';
 import 'package:frontend/user/widgets/cart_widget.dart';
 import 'package:intl/intl.dart';
 
 class CartItemPage extends StatefulWidget {
-  final StoreModel store;
-  final AddMenuModel userMenu;
-  const CartItemPage(this.store, this.userMenu, {super.key});
+  const CartItemPage({super.key});
   @override
   State<CartItemPage> createState() => _CartItemPageState();
 }
@@ -39,13 +36,24 @@ class _CartItemPageState extends State<CartItemPage> {
         ),
         centerTitle: true,
         backgroundColor: const Color(0xFF374AA3),
-        actions: const [
+        actions: [
           // 홈 화면으로 이동
           Padding(
-            padding: EdgeInsets.only(right: 20),
-            child: Icon(
-              Icons.home,
-              color: Colors.white,
+            padding: const EdgeInsets.only(right: 20),
+            child: IconButton(
+              onPressed: () {
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const UserHomePage(),
+                  ),
+                  (route) => false,
+                );
+              },
+              icon: const Icon(
+                Icons.home,
+                color: Colors.white,
+              ),
             ),
           ),
         ],
@@ -53,7 +61,7 @@ class _CartItemPageState extends State<CartItemPage> {
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 24.0),
         child: FutureBuilder<Map<String, dynamic>>(
-          future: CartProvider().getCart(),
+          future: CartService().getCart(),
           builder: (context, snapshot) {
             // 데이터가 로드되는 동안 로딩 스피너 표시
             if (snapshot.connectionState == ConnectionState.waiting) {
@@ -68,19 +76,27 @@ class _CartItemPageState extends State<CartItemPage> {
               // 데이터가 없거나 빈 리스트일 경우 '등록된 가게가 없습니다' 메시지 표시
             } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
               return const Center(
-                child: Text('등록된 장바구니가 없습니다.'),
+                child: Text('장바구니에 담은 메뉴가 없습니다.'),
               );
               // 데이터가 성공적으로 로드될 경우 가게 목록 표시
             } else {
-              final List<dynamic> cartItems = snapshot.data!['cartItems'];
+              final storeName = snapshot.data!['storeName'];
+              // List<CartMenuModel> 타입으로 변환
+              // 이유: FutureBuilder 타입이 Map<String, dynamic>로 되어있어
+              // cartItem안에 Map<String, dynamic>으로 되어있기 때문
+              final List<CartMenuModel> cartItems = List<CartMenuModel>.from(
+                snapshot.data!['cartItems']
+                    .map((item) => CartMenuModel.fromJson(item)),
+              ).toList();
 
               return ListView.builder(
                 shrinkWrap: true,
                 physics: const ScrollPhysics(),
                 itemCount: cartItems.length,
                 itemBuilder: (BuildContext context, int index) {
-                  final Map<String, dynamic> cart = cartItems[index];
-                  return CartWidget(cart);
+                  final CartMenuModel cart =
+                      cartItems[index]; // 하나의 cartItem 변수 지정
+                  return CartWidget(cart, storeName);
                 },
               );
             }
@@ -89,10 +105,10 @@ class _CartItemPageState extends State<CartItemPage> {
       ),
       bottomNavigationBar: ElevatedButton(
         onPressed: () async {
-          Navigator.push(
-            context,
-            downToUpRoute(),
-          );
+          // Navigator.push(
+          //   context,
+          //   downToUpRoute(),
+          // );
         }, // 결제 화면으로 이동
         style: ElevatedButton.styleFrom(
           backgroundColor: const Color(0xFF274AA3),
@@ -113,25 +129,25 @@ class _CartItemPageState extends State<CartItemPage> {
   }
 
   // 아래에서 위로 페이지 이동하는 애니메이션 함수
-  Route downToUpRoute() {
-    return PageRouteBuilder(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          UserOrderPage(widget.store, widget.userMenu),
-      // 페이지 전환 애니메이션 정의(child: 전환될 페이지)
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        const begin = Offset(0.0, 1.0); // 시작점 지정(화면의 아래쪽 의미)
-        const end = Offset.zero; // 원래 위치(화면의 제자리) 지정
-        const curve = Curves.ease; // 부드러운 속도 변화
-        // 시작과 끝을 정의(부드럽게 페이지 이동)
-        var tween = Tween(begin: begin, end: end).chain(
-          CurveTween(curve: curve),
-        );
-        // 위에서 지정했던 애니메이션을 적용하는 위젯
-        return SlideTransition(
-          position: animation.drive(tween),
-          child: child,
-        );
-      },
-    );
-  }
+  // Route downToUpRoute() {
+  //   return PageRouteBuilder(
+  //     pageBuilder: (context, animation, secondaryAnimation) =>
+  //         UserOrderPage(widget.store, widget.userMenu),
+  //     // 페이지 전환 애니메이션 정의(child: 전환될 페이지)
+  //     transitionsBuilder: (context, animation, secondaryAnimation, child) {
+  //       const begin = Offset(0.0, 1.0); // 시작점 지정(화면의 아래쪽 의미)
+  //       const end = Offset.zero; // 원래 위치(화면의 제자리) 지정
+  //       const curve = Curves.ease; // 부드러운 속도 변화
+  //       // 시작과 끝을 정의(부드럽게 페이지 이동)
+  //       var tween = Tween(begin: begin, end: end).chain(
+  //         CurveTween(curve: curve),
+  //       );
+  //       // 위에서 지정했던 애니메이션을 적용하는 위젯
+  //       return SlideTransition(
+  //         position: animation.drive(tween),
+  //         child: child,
+  //       );
+  //     },
+  //   );
+  // }
 }

--- a/lib/user/screens/cart_screen.dart
+++ b/lib/user/screens/cart_screen.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/all/services/order_service.dart';
 import 'package:frontend/owner/models/menu_model.dart';
 import 'package:frontend/owner/models/store_model.dart';
+import 'package:frontend/user/providers/cart_provider.dart';
 import 'package:frontend/user/screens/userOrder_screen.dart';
-import 'package:frontend/user/services/cart_service.dart';
 import 'package:frontend/user/widgets/cart_widget.dart';
 import 'package:intl/intl.dart';
 
@@ -54,7 +53,7 @@ class _CartItemPageState extends State<CartItemPage> {
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 24.0),
         child: FutureBuilder<Map<String, dynamic>>(
-          future: CartService().getCart(),
+          future: CartProvider().getCart(),
           builder: (context, snapshot) {
             // 데이터가 로드되는 동안 로딩 스피너 표시
             if (snapshot.connectionState == ConnectionState.waiting) {
@@ -74,6 +73,7 @@ class _CartItemPageState extends State<CartItemPage> {
               // 데이터가 성공적으로 로드될 경우 가게 목록 표시
             } else {
               final List<dynamic> cartItems = snapshot.data!['cartItems'];
+
               return ListView.builder(
                 shrinkWrap: true,
                 physics: const ScrollPhysics(),

--- a/lib/user/screens/cart_screen.dart
+++ b/lib/user/screens/cart_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/user/models/cartMenu_model.dart';
 import 'package:frontend/user/screens/userHome_screen.dart';
+import 'package:frontend/user/screens/userOrder_screen.dart';
 import 'package:frontend/user/services/cart_service.dart';
 import 'package:frontend/user/widgets/cart_widget.dart';
 import 'package:intl/intl.dart';
@@ -70,8 +71,8 @@ class _CartItemPageState extends State<CartItemPage> {
               );
               // 데이터 로드 중 에러 발생 시 오류 메세지 표시
             } else if (snapshot.hasError) {
-              return Center(
-                child: Text('Error: ${snapshot.error}'),
+              return const Center(
+                child: Text('장바구니에 담은 메뉴가 없습니다.'),
               );
               // 데이터가 없거나 빈 리스트일 경우 '등록된 가게가 없습니다' 메시지 표시
             } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
@@ -105,13 +106,13 @@ class _CartItemPageState extends State<CartItemPage> {
       ),
       bottomNavigationBar: ElevatedButton(
         onPressed: () async {
-          // Navigator.push(
-          //   context,
-          //   downToUpRoute(),
-          // );
+          Navigator.push(
+            context,
+            downToUpRoute(),
+          );
         }, // 결제 화면으로 이동
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF274AA3),
+          backgroundColor: const Color(0xFF374AA3),
           shape: const BeveledRectangleBorder(
             borderRadius: BorderRadiusDirectional.zero,
           ),
@@ -129,25 +130,25 @@ class _CartItemPageState extends State<CartItemPage> {
   }
 
   // 아래에서 위로 페이지 이동하는 애니메이션 함수
-  // Route downToUpRoute() {
-  //   return PageRouteBuilder(
-  //     pageBuilder: (context, animation, secondaryAnimation) =>
-  //         UserOrderPage(widget.store, widget.userMenu),
-  //     // 페이지 전환 애니메이션 정의(child: 전환될 페이지)
-  //     transitionsBuilder: (context, animation, secondaryAnimation, child) {
-  //       const begin = Offset(0.0, 1.0); // 시작점 지정(화면의 아래쪽 의미)
-  //       const end = Offset.zero; // 원래 위치(화면의 제자리) 지정
-  //       const curve = Curves.ease; // 부드러운 속도 변화
-  //       // 시작과 끝을 정의(부드럽게 페이지 이동)
-  //       var tween = Tween(begin: begin, end: end).chain(
-  //         CurveTween(curve: curve),
-  //       );
-  //       // 위에서 지정했던 애니메이션을 적용하는 위젯
-  //       return SlideTransition(
-  //         position: animation.drive(tween),
-  //         child: child,
-  //       );
-  //     },
-  //   );
-  // }
+  Route downToUpRoute() {
+    return PageRouteBuilder(
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          const UserOrderPage(),
+      // 페이지 전환 애니메이션 정의(child: 전환될 페이지)
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        const begin = Offset(0.0, 1.0); // 시작점 지정(화면의 아래쪽 의미)
+        const end = Offset.zero; // 원래 위치(화면의 제자리) 지정
+        const curve = Curves.ease; // 부드러운 속도 변화
+        // 시작과 끝을 정의(부드럽게 페이지 이동)
+        var tween = Tween(begin: begin, end: end).chain(
+          CurveTween(curve: curve),
+        );
+        // 위에서 지정했던 애니메이션을 적용하는 위젯
+        return SlideTransition(
+          position: animation.drive(tween),
+          child: child,
+        );
+      },
+    );
+  }
 }

--- a/lib/user/screens/menuselect_screen.dart
+++ b/lib/user/screens/menuselect_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/menu_model.dart';
 import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/providers/userMenu_provider.dart';
+import 'package:frontend/user/screens/cart_screen.dart';
 import 'package:frontend/user/services/cart_service.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -325,13 +326,15 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
                     try {
                       await CartService().putCart(userMenu);
                       // 장바구니 담기에 성공하면 장바구니에 페이지로 이동
-                      // Navigator.push(
-                      //   context,
-                      //   MaterialPageRoute(
-                      //     builder: (context) =>
-                      //         CartItemPage(widget.store, userMenu),
-                      //   ),
-                      // );
+                      if (context.mounted) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) =>
+                                CartItemPage(widget.store, userMenu),
+                          ),
+                        );
+                      }
                     } catch (e) {
                       // 장바구니에 담은 경우 다른 가게의 메뉴를 담을려고 할 때 경고창 구현
                       if (context.mounted) {

--- a/lib/user/screens/menuselect_screen.dart
+++ b/lib/user/screens/menuselect_screen.dart
@@ -296,6 +296,7 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
     );
   }
 
+  // 가게 메뉴 리스트
   Widget allMenuSection() {
     return FutureBuilder<List<AddMenuModel>>(
       future: getMenuData(),
@@ -333,23 +334,25 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
                       // );
                     } catch (e) {
                       // 장바구니에 담은 경우 다른 가게의 메뉴를 담을려고 할 때 경고창 구현
-                      showDialog(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return AlertDialog(
-                            title: const Text('경고'),
-                            content: const Text('다른 가게의 메뉴를 추가할 수 없습니다.'),
-                            actions: [
-                              TextButton(
-                                onPressed: () {
-                                  Navigator.of(context).pop();
-                                },
-                                child: const Text('확인'),
-                              ),
-                            ],
-                          );
-                        },
-                      );
+                      if (context.mounted) {
+                        showDialog(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return AlertDialog(
+                              title: const Text('경고'),
+                              content: const Text('다른 가게의 메뉴를 추가할 수 없습니다.'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () {
+                                    Navigator.of(context).pop();
+                                  },
+                                  child: const Text('확인'),
+                                ),
+                              ],
+                            );
+                          },
+                        );
+                      }
                     }
                   },
                   child: Card(

--- a/lib/user/screens/menuselect_screen.dart
+++ b/lib/user/screens/menuselect_screen.dart
@@ -3,7 +3,9 @@ import 'package:frontend/owner/models/menu_model.dart';
 import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/providers/userMenu_provider.dart';
 import 'package:frontend/user/screens/cart_screen.dart';
+import 'package:frontend/user/screens/userHome_screen.dart';
 import 'package:frontend/user/services/cart_service.dart';
+import 'package:frontend/user/services/userMenu_service.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
@@ -40,21 +42,43 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
     return Scaffold(
       backgroundColor: const Color(0xFFF3F3FF),
       appBar: AppBar(
-        actions: const [
+        actions: [
           Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.home,
-              size: 30,
-              color: Colors.black,
+            padding: const EdgeInsets.only(right: 23.0),
+            child: IconButton(
+              onPressed: () {
+                // 이전 페이지 스택 모두 제거
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const UserHomePage(),
+                  ),
+                  (route) => false,
+                );
+              },
+              icon: const Icon(
+                Icons.home,
+                size: 30,
+                color: Colors.black,
+              ),
             ),
           ),
           Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.shopping_cart,
-              size: 30,
-              color: Colors.black,
+            padding: const EdgeInsets.only(right: 23.0),
+            child: IconButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const CartItemPage(),
+                  ),
+                );
+              },
+              icon: const Icon(
+                Icons.shopping_cart,
+                size: 30,
+                color: Colors.black,
+              ),
             ),
           ),
         ],
@@ -300,7 +324,7 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
   // 가게 메뉴 리스트
   Widget allMenuSection() {
     return FutureBuilder<List<AddMenuModel>>(
-      future: getMenuData(),
+      future: UserMenuService().fetchMenus(widget.store.id),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(
@@ -330,8 +354,7 @@ class _UserMenuSelectPageState extends State<UserMenuSelectPage> {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) =>
-                                CartItemPage(widget.store, userMenu),
+                            builder: (context) => const CartItemPage(),
                           ),
                         );
                       }

--- a/lib/user/screens/userAddress_screen.dart
+++ b/lib/user/screens/userAddress_screen.dart
@@ -1,18 +1,19 @@
 // UI 수정 필요
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/screens/map_screen.dart';
-import 'package:get/get.dart';
+import 'package:frontend/user/screens/userHome_screen.dart';
 import 'package:kpostal/kpostal.dart';
 import 'dart:io' show Platform;
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
+import 'package:shared_preferences/shared_preferences.dart';
+
 class UserAddressPage extends StatefulWidget {
   final Function(String) onUserAddressSelected;
   Function(String, String, String, String, String) sendAddress;
-  final String accessToken;
 
-  UserAddressPage(this.sendAddress, this.accessToken,
+  UserAddressPage(this.sendAddress,
       {required this.onUserAddressSelected, super.key});
 
   @override
@@ -44,13 +45,16 @@ class _UserAddressPageState extends State<UserAddressPage> {
       serverAddress = 'http://127.0.0.1:9000/api/v1/user/addresses';
     }
 
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken') ?? '';
+
     try {
       final url = Uri.parse(serverAddress);
       final response = await http.post(
         url,
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer ${widget.accessToken}',
+          'Authorization': 'Bearer $accessToken',
         },
         body: jsonEncode({
           'fullAddress': fullAddress,
@@ -279,7 +283,12 @@ class _UserAddressPageState extends State<UserAddressPage> {
               double.parse(latitude),
               double.parse(longitude),
             );
-            Navigator.pop(context);
+            Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const UserHomePage(),
+                ),
+                (route) => false);
           } catch (e) {
             print('위도 및 경도 변환 오류: ${e.toString()}');
           }

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -3,7 +3,7 @@ import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/models/category_model.dart';
 import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/providers/userInfo_provider.dart';
-import 'package:frontend/user/screens/complete_screen.dart';
+import 'package:frontend/user/screens/cart_screen.dart';
 import 'package:frontend/user/screens/storeSelect_screen.dart';
 import 'package:frontend/user/screens/userAddress_screen.dart';
 import 'package:frontend/user/services/userStore_service.dart';
@@ -168,6 +168,8 @@ class _UserHomePageState extends State<UserHomePage> {
               ),
             ),
           ),
+
+          // 장바구니 아이콘
           GestureDetector(
             child: const Padding(
               padding: EdgeInsets.all(8.0),
@@ -181,18 +183,18 @@ class _UserHomePageState extends State<UserHomePage> {
               ),
             ),
             onTap: () async {
-              StoreModel storeModel = await getStoreModel();
+              // StoreModel storeModel = await getStoreModel();
 
-              print('storeModel : $storeModel');
+              // print('storeModel : $storeModel');
 
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => CompletePage(
-                    storeModel,
+              if (context.mounted) {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const CartItemPage(),
                   ),
-                ),
-              );
+                );
+              }
             },
           )
         ],

--- a/lib/user/screens/userHome_screen.dart
+++ b/lib/user/screens/userHome_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/owner/models/store_model.dart';
 import 'package:frontend/user/models/category_model.dart';
+import 'package:frontend/user/providers/cart_provider.dart';
 import 'package:frontend/user/providers/category_provider.dart';
 import 'package:frontend/user/providers/userInfo_provider.dart';
 import 'package:frontend/user/screens/cart_screen.dart';
@@ -26,14 +27,22 @@ class _UserHomePageState extends State<UserHomePage> {
   String userAddress = '주소를 설정하세요'; // 고객 주소
   String fullAddress = '';
 
+  Map<String, dynamic> cart = {};
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Provider.of<CategoryProvider>(context, listen: false).getCategory();
 
-      await Provider.of<UserInfoProvider>(context, listen: false)
-          .fetchUserInfo();
+      if (context.mounted) {
+        await Provider.of<UserInfoProvider>(context, listen: false)
+            .fetchUserInfo();
+      }
+
+      // if (context.mounted) {
+      //   await Provider.of<CartProvider>(context, listen: false).getCart();
+      // }
 
       setState(() {
         List<CategoryModel> getCategories =
@@ -45,6 +54,8 @@ class _UserHomePageState extends State<UserHomePage> {
 
         userInfo =
             Provider.of<UserInfoProvider>(context, listen: false).userInfo;
+
+        // cart = Provider.of<CartProvider>(context, listen: false).cart;
       });
     });
   }
@@ -170,32 +181,53 @@ class _UserHomePageState extends State<UserHomePage> {
           ),
 
           // 장바구니 아이콘
-          GestureDetector(
-            child: const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: Padding(
-                padding: EdgeInsets.only(right: 10.0),
-                child: Icon(
-                  Icons.shopping_cart,
-                  size: 26, // 아이콘 크기 설정
-                  color: Colors.white, // 아이콘 색상 설정
-                ),
-              ),
-            ),
-            onTap: () async {
-              // StoreModel storeModel = await getStoreModel();
-
-              // print('storeModel : $storeModel');
-
-              if (context.mounted) {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const CartItemPage(),
+          Stack(
+            children: [
+              GestureDetector(
+                child: const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: Padding(
+                    padding: EdgeInsets.only(right: 10.0),
+                    child: Icon(
+                      Icons.shopping_cart,
+                      size: 26, // 아이콘 크기 설정
+                      color: Colors.white, // 아이콘 색상 설정
+                    ),
                   ),
-                );
-              }
-            },
+                ),
+                onTap: () async {
+                  // StoreModel storeModel = await getStoreModel();
+
+                  // print('storeModel : $storeModel');
+
+                  if (context.mounted) {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const CartItemPage(),
+                      ),
+                    );
+                  }
+                },
+              ),
+              // if (cart.isNotEmpty)
+              //   if (cart['cartItems'] != null)
+              //     Positioned(
+              //       right: 12,
+              //       top: 5,
+              //       child: Container(
+              //         padding: const EdgeInsets.all(4),
+              //         decoration: BoxDecoration(
+              //           color: Colors.red,
+              //           borderRadius: BorderRadius.circular(12),
+              //         ),
+              //         constraints: const BoxConstraints(
+              //           minWidth: 6,
+              //           minHeight: 6,
+              //         ),
+              //       ),
+              //     ),
+            ],
           )
         ],
       ),

--- a/lib/user/screens/userReview_screen.dart
+++ b/lib/user/screens/userReview_screen.dart
@@ -60,7 +60,7 @@ class _UserReviewPageState extends State<UserReviewPage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => const UserHomePage(''),
+                      builder: (context) => const UserHomePage(),
                     ),
                   );
                 },

--- a/lib/user/screens/userReview_screen.dart
+++ b/lib/user/screens/userReview_screen.dart
@@ -76,8 +76,7 @@ class _UserReviewPageState extends State<UserReviewPage> {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) =>
-                            CartItemPage(widget.store!, widget.userMenu!),
+                        builder: (context) => const CartItemPage(),
                       ),
                     );
                   },

--- a/lib/user/screens/write_screen.dart
+++ b/lib/user/screens/write_screen.dart
@@ -167,8 +167,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) =>
-                            CartItemPage(widget.store, widget.userMenu!),
+                        builder: (context) => const CartItemPage(),
                       ),
                     );
                   },

--- a/lib/user/screens/write_screen.dart
+++ b/lib/user/screens/write_screen.dart
@@ -151,7 +151,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => const UserHomePage(''),
+                      builder: (context) => const UserHomePage(),
                     ),
                   );
                 },

--- a/lib/user/services/cart_service.dart
+++ b/lib/user/services/cart_service.dart
@@ -88,4 +88,41 @@ class CartService {
       throw Exception(e.toString());
     }
   }
+
+  // 장바구니 삭제
+  Future<void> deleteCart(int menuId) async {
+    // SharedPreferences에서 액세스 토큰을 가져옴
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken') ?? '';
+
+    String serverAddress = '';
+    if (Platform.isAndroid) {
+      serverAddress = 'http://10.0.2.2:9000/api/v1/cart/remove/$menuId';
+    } else if (Platform.isIOS) {
+      serverAddress = 'http://127.0.0.1:9000/api/v1/cart/remove/$menuId';
+    }
+
+    try {
+      final url = Uri.parse(serverAddress);
+
+      final response = await http.delete(
+        url,
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final utf8Response = utf8.decode(response.bodyBytes);
+        final jsonResponse = jsonDecode(utf8Response);
+        // final dataResponse = jsonResponse['data'];
+
+        print('장바구니 삭제 성공: $jsonResponse');
+      } else {
+        throw Exception('장바구니 조회 실패: ${response.statusCode}');
+      }
+    } catch (e) {
+      throw Exception(e.toString());
+    }
+  }
 }

--- a/lib/user/services/cart_service.dart
+++ b/lib/user/services/cart_service.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
 import 'package:frontend/owner/models/menu_model.dart';
-import 'package:frontend/user/models/cartMenu_model.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -42,9 +41,9 @@ class CartService {
       if (response.statusCode == 200) {
         final utf8Response = utf8.decode(response.bodyBytes);
         final jsonResponse = jsonDecode(utf8Response);
-        print('담기 성공: $jsonResponse');
+        print('장바구니 담기 성공: $jsonResponse');
       } else {
-        throw Exception('담기 실패: ${response.body}');
+        throw Exception('장바구니 담기 실패: ${response.body}');
       }
     } catch (e) {
       print('Error: $e');
@@ -52,6 +51,7 @@ class CartService {
     }
   }
 
+  // 장바구니 조회
   Future<Map<String, dynamic>> getCart() async {
     // SharedPreferences에서 액세스 토큰을 가져옴
     final prefs = await SharedPreferences.getInstance();
@@ -76,24 +76,16 @@ class CartService {
 
       if (response.statusCode == 200) {
         final utf8Response = utf8.decode(response.bodyBytes);
-        final dynamic jsonResponse = jsonDecode(utf8Response);
+        final jsonResponse = jsonDecode(utf8Response);
+        final dataResponse = jsonResponse['data'];
 
-        if (jsonResponse is Map<String, dynamic> &&
-            jsonResponse['data'] is Map<String, dynamic>) {
-          final carts = jsonResponse['data'];
-          print('JSON 데이터: ${jsonResponse['data']}');
-          return carts;
-        } else {
-          print('잘못된 응답 형식');
-          return {};
-        }
+        print('장바구니 조회 성공: ${jsonResponse['data']}');
+        return dataResponse;
       } else {
-        print('조회 실패: ${response.statusCode}');
-        return {};
+        throw Exception('장바구니 조회 실패: ${response.statusCode}');
       }
     } catch (e) {
-      print(e.toString());
-      return {};
+      throw Exception(e.toString());
     }
   }
 }

--- a/lib/user/services/userInfo_service.dart
+++ b/lib/user/services/userInfo_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserInfoService {
+  String serverAddress = '';
+
+  // 유저 정보 검색
+  Future<Map<String, dynamic>> fetchUserInfo() async {
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken') ?? '';
+
+    if (Platform.isAndroid) {
+      serverAddress = 'http://10.0.2.2:9000/api/v1/user/info';
+    } else if (Platform.isIOS) {
+      serverAddress = 'http://127.0.0.1:9000/api/v1/user/info';
+    }
+    try {
+      final url = Uri.parse(serverAddress);
+      final headers = {
+        'Authorization': 'Bearer $accessToken',
+        'Content-Type': 'application/json',
+      };
+      final response = await http.get(
+        url,
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final utf8Response = utf8.decode(response.bodyBytes);
+        final jsonResponse = jsonDecode(utf8Response);
+
+        print('유저 정보 검색 성공: $jsonResponse');
+        return jsonResponse;
+      } else {
+        throw Exception('조회 실패: ${response.statusCode} - ${response.body}');
+      }
+    } catch (e) {
+      throw Exception(e.toString());
+    }
+  }
+}

--- a/lib/user/services/userStore_service.dart
+++ b/lib/user/services/userStore_service.dart
@@ -64,4 +64,42 @@ class UserStoreService {
       return [];
     }
   }
+
+  // 가게 조회
+  Future<Map<String, dynamic>> getStore(int storeId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken') ?? '';
+
+    if (Platform.isAndroid) {
+      serverAddress = 'http://10.0.2.2:9000/api/v1/store/$storeId';
+    } else if (Platform.isIOS) {
+      serverAddress = 'http://127.0.0.1:9000/api/v1/store/$storeId';
+    }
+
+    try {
+      final url = Uri.parse(serverAddress);
+      final response = await http.get(
+        url,
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final utf8Response = utf8.decode(response.bodyBytes);
+        final jsonResponse = jsonDecode(utf8Response);
+        final dataResponse = jsonResponse['data'];
+
+        Map<String, dynamic> store = dataResponse;
+
+        print('가게 조회 성공: $dataResponse');
+        return store;
+      } else {
+        throw Exception(
+            '가게 조회 실패코드 - 응답 본문: ${response.statusCode} - ${response.body}');
+      }
+    } catch (e) {
+      throw Exception('예외 발생: $e');
+    }
+  }
 }

--- a/lib/user/widgets/cart_widget.dart
+++ b/lib/user/widgets/cart_widget.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:cart_stepper/cart_stepper.dart';
+import 'package:frontend/user/models/cartMenu_model.dart';
+import 'package:frontend/user/services/cart_service.dart';
 import 'package:intl/intl.dart';
 
 class CartWidget extends StatefulWidget {
-  final Map<String, dynamic> cart;
-  const CartWidget(this.cart, {super.key});
+  final CartMenuModel cart;
+  final String storeName;
+  const CartWidget(this.cart, this.storeName, {super.key});
   @override
   State<CartWidget> createState() => _CartWidgetState();
 }
@@ -19,7 +22,7 @@ class _CartWidgetState extends State<CartWidget> {
       alignment: AlignmentDirectional.bottomCenter,
       children: [
         SizedBox(
-          height: 230, // 275,
+          height: MediaQuery.of(context).size.width / 1.6,
           child: Card(
             color: Colors.white,
             shadowColor: const Color(0xFF374AA3),
@@ -29,41 +32,30 @@ class _CartWidgetState extends State<CartWidget> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     // 주문 가게 이름
                     children: [
                       // 추후에 구현 예정
-                      // Text(
-                      //   carts.menuName,
-                      //   style: const TextStyle(
-                      //     fontSize: 16,
-                      //     color: Color(0xFF808080),
-                      //   ),
-                      // ),
-                      // 삭제 버튼
-                      // IconButton(
-                      //   onPressed: () {},
-                      //   icon: const Icon(
-                      //     Icons.delete,
-                      //     color: Color(0xFF7E7EB2),
-                      //   ),
-                      // ),
-                    ],
-                  ),
-                  // 주문 메뉴 이름
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
                       Text(
-                        widget.cart['menuName'],
+                        widget.storeName,
                         style: const TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                          color: Color(0xFF808080),
                         ),
                       ),
+
+                      // 삭제 버튼
                       IconButton(
-                        onPressed: () {},
+                        onPressed: () async {
+                          try {
+                            await CartService().deleteCart(widget.cart.menuId);
+                          } catch (e) {
+                            print(e.toString());
+                          }
+
+                          setState(() {});
+                        },
                         icon: const Icon(
                           Icons.delete,
                           color: Color(0xFF7E7EB2),
@@ -71,7 +63,17 @@ class _CartWidgetState extends State<CartWidget> {
                       ),
                     ],
                   ),
+
+                  // 주문 메뉴 이름
+                  Text(
+                    widget.cart.menuName,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                   const SizedBox(height: 20),
+
                   // 주문 가격과 수량
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -80,15 +82,16 @@ class _CartWidgetState extends State<CartWidget> {
                       ClipRRect(
                         borderRadius: BorderRadius.circular(10.0),
                         child: Image.network(
-                          widget.cart['imageUrl'],
+                          widget.cart.imageUrl,
                           width: 120,
                           alignment: Alignment.topLeft,
                         ),
                       ),
                       Row(
                         children: [
-                          Text('${widget.cart['price']}원'),
+                          Text('${widget.cart.price}원'),
                           const SizedBox(width: 10),
+
                           // 수량 증가/감소 버튼
                           CartStepperInt(
                             value: counterLimit,

--- a/lib/user/widgets/cart_widget.dart
+++ b/lib/user/widgets/cart_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cart_stepper/cart_stepper.dart';
 import 'package:frontend/user/models/cartMenu_model.dart';
+
 import 'package:frontend/user/services/cart_service.dart';
 import 'package:intl/intl.dart';
 
@@ -144,7 +145,7 @@ class _CartWidgetState extends State<CartWidget> {
               // Navigator.push(
               //   context,
               //   MaterialPageRoute(
-              //     builder: (context) => UserMenuPage(category: category),
+              //     builder: (context) => const StoreSelectPage(),
               //   ),
               // );
             },

--- a/lib/user/widgets/orderAndPay_widget.dart
+++ b/lib/user/widgets/orderAndPay_widget.dart
@@ -45,7 +45,7 @@ class OrderAndPayBtn extends StatelessWidget {
   Route downToUpRoute() {
     return PageRouteBuilder(
       pageBuilder: (context, animation, secondaryAnimation) =>
-          UserOrderPage(store, userMenu),
+          const UserOrderPage(),
 
       // 페이지 전환 애니메이션 정의(child: 전환될 페이지)
       transitionsBuilder: (context, animation, secondaryAnimation, child) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#119

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### accessToken 관련 코드 수정
- accessToken을 sharePreference에서 꺼내오는 방식으로 변경하고 데이터 전달 코드 제거
### 유저 정보 검색 api 및 provider 구현
- userHome에서 배달하기 전에 주소 먼저 설정할 수 있도록 기능 구현
### 장바구니 담기 및 조회 api, provider 구현
- Provider에도 리턴 타입 지정
### 장바구니 조회 api 및 provider 구현
- provider는 데이터 전달 없이 값을 가져오려고 할 때 사용하는 걸로 결정
- service는 FutureBuilder 사용할 때 사용하는 걸로 결정
### 주문하기 api 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
